### PR TITLE
Added start and end functionality for single video embed

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/kmcECG.iml
+++ b/.idea/kmcECG.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/kmcECG.iml" filepath="$PROJECT_DIR$/.idea/kmcECG.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/index.html
+++ b/index.html
@@ -21,12 +21,20 @@
   <input type="text" id="entryIdInput"> <br>
 
   <div class="dimensions-container">
-  <label for="videoWidth">Width:</label>
-  <input type="number" id="videoWidth" value="600">
+    <label for="videoWidth">Width:</label>
+    <input type="number" id="videoWidth" value="600">
 
-  <label for="videoHeight">Height:</label>
-  <input type="number" id="videoHeight" value="400">
-</div>
+    <label for="videoHeight">Height:</label>
+    <input type="number" id="videoHeight" value="400">
+  </div>
+
+  <div class="dimensions-container">
+    <label for="videoStart">Start at:</label>
+    <input type="number" id="videoStart" value="0">
+
+    <label for="videoEnd">End at:</label>
+    <input type="number" id="videoEnd" value="0">
+  </div>
 
   <button id="generateButton">Generate</button>
  

--- a/script.js
+++ b/script.js
@@ -44,8 +44,20 @@ document.addEventListener("DOMContentLoaded", function() {
 
   var iframeHeight = document.getElementById("videoHeight").value;
 
+  // Start at and End at
+  var start_at = document.getElementById("videoStart").value;
+  var end_at = document.getElementById("videoEnd").value;
+
+  var iframeSRC = `https://cdnapisec.kaltura.com/p/1157612/sp/115761200/embedIframeJs/uiconf_id/${uiconf_id}/partner_id/1157612?iframeembed=true&playerId=${playerId}&entry_id=${entryId}`;
+  if (parseInt(start_at) > 0){
+    iframeSRC = iframeSRC + `&flashvars[mediaProxy.mediaPlayFrom]=${start_at}`;
+  }
+  if (parseInt(end_at) > 0){
+    iframeSRC = iframeSRC + `&flashvars[mediaProxy.mediaPlayTo]=${end_at}`;
+  }
+
   var iframe = document.createElement('iframe');
-    iframe.setAttribute('src', 'https://cdnapisec.kaltura.com/p/1157612/sp/115761200/embedIframeJs/uiconf_id/' + uiconf_id + '/partner_id/1157612?iframeembed=true&playerId=' + playerId + '&entry_id=' + entryId);
+    iframe.setAttribute('src', iframeSRC);
     iframe.setAttribute('width', iframeWidth);
     iframe.setAttribute('height', iframeHeight);
     iframe.setAttribute('allowfullscreen', 'allowfullscreen');


### PR DESCRIPTION
This pull request includes several changes to the project configuration files and enhancements to the video embed functionality. The most important changes include updates to the `.idea` directory files, and modifications to the `index.html` and `script.js` files to support specifying start and end times for video playback.

### Project configuration updates:

* [`.idea/.gitignore`](diffhunk://#diff-21610973868a98feff98dd0460438a8a32cca1447bc8701537ec5048e0c5faebR1-R5): Added default ignored files and directories for the project.
* [`.idea/kmcECG.iml`](diffhunk://#diff-f9aeac4ba8e21c1c97750f415545c25d1295bb1cc8655bd5457bf83303314290R1-R12): Created a new module configuration file, excluding temporary directories.
* [`.idea/modules.xml`](diffhunk://#diff-0aae258f1732eac2acd4fcdd1af6d0737b4ec8d233136c3ba7c40b6d49aeda50R1-R8): Added project module manager configuration.
* [`.idea/vcs.xml`](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aR1-R6): Configured VCS directory mappings for Git.

### Video embed functionality enhancements:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R31-R38): Added input fields to specify start and end times for video playback.
* [`script.js`](diffhunk://#diff-ed3ee7e0beea2498ff3b8ca85973d122fc6fa3d585d62b5807ec034d0cf076b3R47-R60): Updated the script to include start and end times in the video embed URL if specified.