### PR TITLE
Switch embeds to Playkit URL pattern

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,8 +79,8 @@ function getSeconds(inputValue) {
   var videoType = document.querySelector('input[name="videoType"]:checked').value;
   
   var playerId = "kaltura_player_" + (new Date()).getTime(); // Unique player ID for each generation
-  
-  var uiconf_id = videoType === "downloadable" ? "47306393" : "42438262"; // Adjusted based on video type
+
+  var uiconf_id = videoType === "downloadable" ? "57482403" : "57482393"; // Adjusted based on video type
 
 
   
@@ -96,7 +96,7 @@ function getSeconds(inputValue) {
   var start_at = getSeconds(document.getElementById("videoStart").value);
   var end_at = getSeconds(document.getElementById("videoEnd").value);
 
-  var srcURL = `https://cdnapisec.kaltura.com/p/1157612/sp/115761200/embedIframeJs/uiconf_id/${uiconf_id}/partner_id/1157612?iframeembed=true&playerId=${playerId}&entry_id=${entryId}`
+  var srcURL = `https://cdnapisec.kaltura.com/p/1157612/embedPlaykitJs/uiconf_id/${uiconf_id}?iframeembed=true&entry_id=${entryId}`
   if(start_at > 0) {
     srcURL = srcURL + `&flashvars[mediaProxy.mediaPlayFrom]=${start_at}`
   }
@@ -160,7 +160,7 @@ function generatePlaylistEmbedCode() {
   var iframeWidth = document.getElementById("frameWidth").value;
 
   var iframeHeight = document.getElementById("frameHeight").value;
-  var url = 'https://cdnapisec.kaltura.com/p/1157612/sp/115761200/embedIframeJs/uiconf_id/'+ player +'/partner_id/1157612?iframeembed=true&playerId=' + playerId + '&flashvars[playlistAPI.kpl0Id]=' + playlistId + flashvars;
+  var url = 'https://cdnapisec.kaltura.com/p/1157612/embedPlaykitJs/uiconf_id/' + player + '?iframeembed=true&flashvars[playlistAPI.kpl0Id]=' + playlistId + flashvars;
   // Playlist embed code
   var playlistEmbedCode = '<iframe id="' + playerId + '" src="'+url+'" width="'+iframeWidth+'" height="'+iframeHeight+'" allowfullscreen webkitallowfullscreen mozAllowFullScreen allow="autoplay *; fullscreen *; encrypted-media *" frameborder="0"></iframe>';
 
@@ -171,7 +171,7 @@ function generatePlaylistEmbedCode() {
   playlistContainer.innerHTML = '';  // Clear previous preview if any
 
   var iframe = document.createElement('iframe');
-    iframe.setAttribute('src', 'https://cdnapisec.kaltura.com/p/1157612/sp/115761200/embedIframeJs/uiconf_id/'+ player +'/partner_id/1157612?iframeembed=true&playerId=' + playerId + '&flashvars[playlistAPI.kpl0Id]=' + playlistId + flashvars);
+    iframe.setAttribute('src', 'https://cdnapisec.kaltura.com/p/1157612/embedPlaykitJs/uiconf_id/' + player + '?iframeembed=true&flashvars[playlistAPI.kpl0Id]=' + playlistId + flashvars);
     iframe.setAttribute('width', iframeWidth);
     iframe.setAttribute('height', iframeHeight);
     iframe.setAttribute('allowfullscreen', 'allowfullscreen');


### PR DESCRIPTION
## Summary
- update single-entry embeds to use the new Playkit JavaScript endpoint and query string
- adjust generated playlist URLs and preview iframes to follow the Playkit path as well

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f94451fe248330b37c192afaab3e60